### PR TITLE
fix: remove 'v' prefix in `spinCompatibilty` in example manifest

### DIFF
--- a/manifests/example/example.json
+++ b/manifests/example/example.json
@@ -3,7 +3,7 @@
     "description": "A description of the plugin.",
     "homepage": "www.example.com",
     "version": "0.2",
-    "spinCompatibility": ">=v0.4, <=5.0",
+    "spinCompatibility": ">=0.4, <=5.0",
     "license": "MIT",
     "packages": [
         {

--- a/manifests/example/example@0.1.json
+++ b/manifests/example/example@0.1.json
@@ -3,7 +3,7 @@
     "description": "A description of the plugin.",
     "homepage": "www.example.com",
     "version": "0.1",
-    "spinCompatibility": "=v0.4",
+    "spinCompatibility": "=0.4",
     "license": "MIT",
     "packages": [
         {


### PR DESCRIPTION
Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>