### PR TITLE
fix: change example.json license to "Apache-2.0"

### DIFF
--- a/manifests/example/example.json
+++ b/manifests/example/example.json
@@ -4,7 +4,7 @@
     "homepage": "www.example.com",
     "version": "0.2.0",
     "spinCompatibility": ">=0.4, <=5.0",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "packages": [
         {
             "os": "linux",

--- a/manifests/example/example@0.1.0.json
+++ b/manifests/example/example@0.1.0.json
@@ -4,7 +4,7 @@
     "homepage": "www.example.com",
     "version": "0.1.0",
     "spinCompatibility": "=0.4",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "packages": [
         {
             "os": "linux",


### PR DESCRIPTION
Previously, it was "MIT", but example.license contained the Apache 2.0 license.
Now they match.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>