### PR TITLE
Fix: use 'macos' instead of 'osx' in schema

### DIFF
--- a/json-schema/spin-plugin-manifest-schema-0.1.json
+++ b/json-schema/spin-plugin-manifest-schema-0.1.json
@@ -47,7 +47,7 @@
                         "type": "string",
                         "enum": [
                             "linux",
-                            "osx",
+                            "macos",
                             "windows"
                         ]
                     },

--- a/manifests/example/example.json
+++ b/manifests/example/example.json
@@ -13,7 +13,7 @@
             "sha256": "7827de0de5e1f5660b9685a43c8011549c1bd41dd52c458dc03ef6d33704ea16"
         },
         {
-            "os": "osx",
+            "os": "macos",
             "arch": "aarch64",
             "url": "https://raw.githubusercontent.com/fermyon/spin-plugins/main/example/example.tar.gz",
             "sha256": "7827de0de5e1f5660b9685a43c8011549c1bd41dd52c458dc03ef6d33704ea16"

--- a/manifests/example/example@0.1.0.json
+++ b/manifests/example/example@0.1.0.json
@@ -13,7 +13,7 @@
             "sha256": "7827de0de5e1f5660b9685a43c8011549c1bd41dd52c458dc03ef6d33704ea16"
         },
         {
-            "os": "osx",
+            "os": "macos",
             "arch": "aarch64",
             "url": "https://raw.githubusercontent.com/fermyon/spin-plugins/main/example/example.tar.gz",
             "sha256": "7827de0de5e1f5660b9685a43c8011549c1bd41dd52c458dc03ef6d33704ea16"


### PR DESCRIPTION
Seems like macos is the best/latest naming
Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>