### PR TITLE
Make example manifests always compatible with spin

### DIFF
--- a/manifests/example/example.json
+++ b/manifests/example/example.json
@@ -3,7 +3,7 @@
     "description": "A description of the plugin.",
     "homepage": "www.example.com",
     "version": "0.2.0",
-    "spinCompatibility": ">=0.4, <=5.0",
+    "spinCompatibility": ">=0.4",
     "license": "Apache-2.0",
     "packages": [
         {

--- a/manifests/example/example@0.1.0.json
+++ b/manifests/example/example@0.1.0.json
@@ -3,7 +3,7 @@
     "description": "A description of the plugin.",
     "homepage": "www.example.com",
     "version": "0.1.0",
-    "spinCompatibility": "=0.4",
+    "spinCompatibility": ">=0.4",
     "license": "Apache-2.0",
     "packages": [
         {


### PR DESCRIPTION
enables always being able to test the following without a compatibility error: `spin plugin upgrade example -d --version 0.1.0`
Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>