### PR TITLE
Rename amd64 to x86_64 and add x86 target

### DIFF
--- a/json-schema/spin-plugin-manifest-schema-0.1.json
+++ b/json-schema/spin-plugin-manifest-schema-0.1.json
@@ -54,7 +54,9 @@
                     "arch": {
                         "type": "string",
                         "enum": [
-                            "amd64",
+                            "x86",
+                            "x86_64",
+                            "arm",
                             "aarch64"
                         ]
                     },

--- a/manifests/example/example.json
+++ b/manifests/example/example.json
@@ -8,7 +8,7 @@
     "packages": [
         {
             "os": "linux",
-            "arch": "amd64",
+            "arch": "x86_64",
             "url": "https://raw.githubusercontent.com/fermyon/spin-plugins/main/example/example.tar.gz",
             "sha256": "7827de0de5e1f5660b9685a43c8011549c1bd41dd52c458dc03ef6d33704ea16"
         },

--- a/manifests/example/example@0.1.0.json
+++ b/manifests/example/example@0.1.0.json
@@ -8,7 +8,7 @@
     "packages": [
         {
             "os": "linux",
-            "arch": "amd64",
+            "arch": "x86_64",
             "url": "https://raw.githubusercontent.com/fermyon/spin-plugins/main/example/example.tar.gz",
             "sha256": "7827de0de5e1f5660b9685a43c8011549c1bd41dd52c458dc03ef6d33704ea16"
         },


### PR DESCRIPTION
Better matches rust consts: https://doc.rust-lang.org/std/env/consts/constant.ARCH.html
Signed-off-by: Kate Goldenring <kate.goldenring@fermyon.com>