### PR TITLE
Load `example.json` from the correct location

### DIFF
--- a/create-manifest.sh
+++ b/create-manifest.sh
@@ -7,7 +7,7 @@ NAME=${1:-temp}
 echo "Creating a new manifest for Spin plugin ${NAME}."
 
 PLUGIN_DIR="${SCRIPT_DIR}/manifests/${NAME}"
-EXAMPLE_PLUGIN="${SCRIPT_DIR}/manifests/example/example.json"
+EXAMPLE_PLUGIN="${SCRIPT_DIR}/example/example.json"
 mkdir $PLUGIN_DIR
 PLUGIN_MANIFEST="${PLUGIN_DIR}/${NAME}.json"
 echo "" > $PLUGIN_MANIFEST


### PR DESCRIPTION
the `create-manifest.sh` script fails because it tries to load `example.json` from a wrong path. With this PR, this issue will be fixed.