### PR TITLE
chore(manifests): bump cloud to v0.3.0

### DIFF
--- a/manifests/cloud/cloud.json
+++ b/manifests/cloud/cloud.json
@@ -2,39 +2,39 @@
   "name": "cloud",
   "description": "Commands for publishing applications to the Fermyon Cloud.",
   "homepage": "https://github.com/fermyon/cloud-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "spinCompatibility": ">=1.3",
   "license": "Apache-2.0",
   "packages": [
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-linux-amd64.tar.gz",
-      "sha256": "014da514d12946b2dee1e6c83f60d5a3dc124d53bbe099eb02e6eb73548fe773"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.3.0/cloud-v0.3.0-linux-amd64.tar.gz",
+      "sha256": "081d8c7a82e38e9757624803d7914262f7dd52470fccc20de451dae5f93aa229"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-linux-aarch64.tar.gz",
-      "sha256": "372837a303af8d988875521d5e3b6a2ddc0a8af3cc952fae17186380641e17a2"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.3.0/cloud-v0.3.0-linux-aarch64.tar.gz",
+      "sha256": "8a4bb6e83abc68a6d8491f545fbde8cb8ad35f8f740bd83e4e5a79c39f809be1"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-macos-aarch64.tar.gz",
-      "sha256": "5d1855b0c517ee0dfaf51c1bc813587610aa53a16bffedbffb7916f95c68e863"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.3.0/cloud-v0.3.0-macos-aarch64.tar.gz",
+      "sha256": "bc5185d7f9134abd83fdcb80eafde188b18b20740adad0bc9368761722fc5872"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-macos-amd64.tar.gz",
-      "sha256": "de56f8d1e9364f0b6b66051854ccd744177637cd5c5d67b369493712c562fcf6"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.3.0/cloud-v0.3.0-macos-amd64.tar.gz",
+      "sha256": "b9565b57720cc4667687065e436f11b218c44bad27c844ad73f47517637f8deb"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-windows-amd64.tar.gz",
-      "sha256": "2d6a11200ae72f335f2ca1d6d898018eebff764c2979bf9936c86fe83b0e0c0d"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.3.0/cloud-v0.3.0-windows-amd64.tar.gz",
+      "sha256": "8192e5a6ef88cf8121d8dcb1486fbc992930f871d3245cedece24745128e4413"
     }
   ]
 }

--- a/manifests/cloud/cloud@0.2.0.json
+++ b/manifests/cloud/cloud@0.2.0.json
@@ -1,0 +1,40 @@
+{
+  "name": "cloud",
+  "description": "Commands for publishing applications to the Fermyon Cloud.",
+  "homepage": "https://github.com/fermyon/cloud-plugin",
+  "version": "0.2.0",
+  "spinCompatibility": ">=1.3",
+  "license": "Apache-2.0",
+  "packages": [
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-linux-amd64.tar.gz",
+      "sha256": "014da514d12946b2dee1e6c83f60d5a3dc124d53bbe099eb02e6eb73548fe773"
+    },
+    {
+      "os": "linux",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-linux-aarch64.tar.gz",
+      "sha256": "372837a303af8d988875521d5e3b6a2ddc0a8af3cc952fae17186380641e17a2"
+    },
+    {
+      "os": "macos",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-macos-aarch64.tar.gz",
+      "sha256": "5d1855b0c517ee0dfaf51c1bc813587610aa53a16bffedbffb7916f95c68e863"
+    },
+    {
+      "os": "macos",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-macos-amd64.tar.gz",
+      "sha256": "de56f8d1e9364f0b6b66051854ccd744177637cd5c5d67b369493712c562fcf6"
+    },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.2.0/cloud-v0.2.0-windows-amd64.tar.gz",
+      "sha256": "2d6a11200ae72f335f2ca1d6d898018eebff764c2979bf9936c86fe83b0e0c0d"
+    }
+  ]
+}


### PR DESCRIPTION
Ref https://github.com/fermyon/cloud-plugin/releases/tag/v0.3.0