### PR TITLE
chore(manifests): bump cloud to 0.4.1

### DIFF
--- a/manifests/cloud/cloud.json
+++ b/manifests/cloud/cloud.json
@@ -2,39 +2,39 @@
   "name": "cloud",
   "description": "Commands for publishing applications to the Fermyon Cloud.",
   "homepage": "https://github.com/fermyon/cloud-plugin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "spinCompatibility": ">=1.3",
   "license": "Apache-2.0",
   "packages": [
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-linux-amd64.tar.gz",
-      "sha256": "207ff7c2004a5f4a5af1776a8419d292668fd4492229c8fcd4cf88b7f2c2afd0"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-linux-amd64.tar.gz",
+      "sha256": "2a2407a58913dfb4b0ecc3873663912f3a2cff12317997dfe50db8362e2dd6be"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-linux-aarch64.tar.gz",
-      "sha256": "00e92d283a1be215d33fe2057a01ee659edfdbd68da626f8f6aeea47acac0fe7"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-linux-aarch64.tar.gz",
+      "sha256": "2d7fdd2d3a2b0a6cd807a2d1a774217fa94191115023c7bf7e6cdbd8ffca4269"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-macos-aarch64.tar.gz",
-      "sha256": "746fff49a24d1a9337bb4b958520c7ca49a3fef66c64444f03a3e8c34406b582"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-macos-aarch64.tar.gz",
+      "sha256": "d49ba13a32aa5f9aed9da9c831f5914854649c93148dc40521d7f14266b2cb49"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-macos-amd64.tar.gz",
-      "sha256": "54ed570ccec0fb2c1990e91f0d4dc8ebb2bc37ae5b56d1be6f25762a4dd5ee97"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-macos-amd64.tar.gz",
+      "sha256": "9d1ca51e751eb3de70f0f4de8e75c590fb5b02ca2b7966f56fc53f9b25a5d17d"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-windows-amd64.tar.gz",
-      "sha256": "6532f3b19d88131e8c42b4c8a359b142d8640bc660bb58a9960cbe7a5a0bf890"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-windows-amd64.tar.gz",
+      "sha256": "cd64a5311a574c87fa38ed2d4d183609c76734e59208da60038e5779fe01e729"
     }
   ]
 }

--- a/manifests/cloud/cloud@0.4.0.json
+++ b/manifests/cloud/cloud@0.4.0.json
@@ -1,0 +1,40 @@
+{
+  "name": "cloud",
+  "description": "Commands for publishing applications to the Fermyon Cloud.",
+  "homepage": "https://github.com/fermyon/cloud-plugin",
+  "version": "0.4.0",
+  "spinCompatibility": ">=1.3",
+  "license": "Apache-2.0",
+  "packages": [
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-linux-amd64.tar.gz",
+      "sha256": "207ff7c2004a5f4a5af1776a8419d292668fd4492229c8fcd4cf88b7f2c2afd0"
+    },
+    {
+      "os": "linux",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-linux-aarch64.tar.gz",
+      "sha256": "00e92d283a1be215d33fe2057a01ee659edfdbd68da626f8f6aeea47acac0fe7"
+    },
+    {
+      "os": "macos",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-macos-aarch64.tar.gz",
+      "sha256": "746fff49a24d1a9337bb4b958520c7ca49a3fef66c64444f03a3e8c34406b582"
+    },
+    {
+      "os": "macos",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-macos-amd64.tar.gz",
+      "sha256": "54ed570ccec0fb2c1990e91f0d4dc8ebb2bc37ae5b56d1be6f25762a4dd5ee97"
+    },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.0/cloud-v0.4.0-windows-amd64.tar.gz",
+      "sha256": "6532f3b19d88131e8c42b4c8a359b142d8640bc660bb58a9960cbe7a5a0bf890"
+    }
+  ]
+}


### PR DESCRIPTION
Ref https://github.com/fermyon/cloud-plugin/releases/tag/v0.4.1