### PR TITLE
Cloud plugin 0.5.0

### DIFF
--- a/manifests/cloud/cloud.json
+++ b/manifests/cloud/cloud.json
@@ -2,39 +2,39 @@
   "name": "cloud",
   "description": "Commands for publishing applications to the Fermyon Cloud.",
   "homepage": "https://github.com/fermyon/cloud-plugin",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "spinCompatibility": ">=1.3",
   "license": "Apache-2.0",
   "packages": [
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-linux-amd64.tar.gz",
-      "sha256": "2a2407a58913dfb4b0ecc3873663912f3a2cff12317997dfe50db8362e2dd6be"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.5.0/cloud-v0.5.0-linux-amd64.tar.gz",
+      "sha256": "9f1ad9bd7ead08b1d83dc7f4856088d68f75020e81cc84c796f6e18bd2507db3"
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-linux-aarch64.tar.gz",
-      "sha256": "2d7fdd2d3a2b0a6cd807a2d1a774217fa94191115023c7bf7e6cdbd8ffca4269"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.5.0/cloud-v0.5.0-linux-aarch64.tar.gz",
+      "sha256": "426411af375ecf6c4421b533206534037adc9f6d8c0675fa2e643d1b6465c61f"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-macos-aarch64.tar.gz",
-      "sha256": "d49ba13a32aa5f9aed9da9c831f5914854649c93148dc40521d7f14266b2cb49"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.5.0/cloud-v0.5.0-macos-aarch64.tar.gz",
+      "sha256": "880e5109fafda98164f84eb13d44ca9db4065e6da43b7c39ce0f328c93273f61"
     },
     {
       "os": "macos",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-macos-amd64.tar.gz",
-      "sha256": "9d1ca51e751eb3de70f0f4de8e75c590fb5b02ca2b7966f56fc53f9b25a5d17d"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.5.0/cloud-v0.5.0-macos-amd64.tar.gz",
+      "sha256": "0cd905b2c0c616e651cdde45ee8f02a82049531c40e27bb8d75a1a899dc22995"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-windows-amd64.tar.gz",
-      "sha256": "cd64a5311a574c87fa38ed2d4d183609c76734e59208da60038e5779fe01e729"
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.5.0/cloud-v0.5.0-windows-amd64.tar.gz",
+      "sha256": "54710e45f8387d4fe60163ec789273d9966d4e89dc8c1910f4a07207f7d6e83f"
     }
   ]
 }

--- a/manifests/cloud/cloud@0.4.1.json
+++ b/manifests/cloud/cloud@0.4.1.json
@@ -1,0 +1,40 @@
+{
+  "name": "cloud",
+  "description": "Commands for publishing applications to the Fermyon Cloud.",
+  "homepage": "https://github.com/fermyon/cloud-plugin",
+  "version": "0.4.1",
+  "spinCompatibility": ">=1.3",
+  "license": "Apache-2.0",
+  "packages": [
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-linux-amd64.tar.gz",
+      "sha256": "2a2407a58913dfb4b0ecc3873663912f3a2cff12317997dfe50db8362e2dd6be"
+    },
+    {
+      "os": "linux",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-linux-aarch64.tar.gz",
+      "sha256": "2d7fdd2d3a2b0a6cd807a2d1a774217fa94191115023c7bf7e6cdbd8ffca4269"
+    },
+    {
+      "os": "macos",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-macos-aarch64.tar.gz",
+      "sha256": "d49ba13a32aa5f9aed9da9c831f5914854649c93148dc40521d7f14266b2cb49"
+    },
+    {
+      "os": "macos",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-macos-amd64.tar.gz",
+      "sha256": "9d1ca51e751eb3de70f0f4de8e75c590fb5b02ca2b7966f56fc53f9b25a5d17d"
+    },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/cloud-plugin/releases/download/v0.4.1/cloud-v0.4.1-windows-amd64.tar.gz",
+      "sha256": "cd64a5311a574c87fa38ed2d4d183609c76734e59208da60038e5779fe01e729"
+    }
+  ]
+}


### PR DESCRIPTION
**Hold** to ship with Spin 2.

(Note Spin 2 is not a version requirement. This will work with Spin 1.x. But we don't want to enable deploying Spin 2 apps until Spin 2 is final. (But we did the release so that we could have this ready to go.))