### PR TITLE
add deprecation notice to py2wasm

### DIFF
--- a/manifests/py2wasm/py2wasm.json
+++ b/manifests/py2wasm/py2wasm.json
@@ -1,6 +1,6 @@
 {
   "name": "py2wasm",
-  "description": "A plugin to convert Python applications to Spin compatible modules",
+  "description": "A plugin to convert Python applications to Spin compatible modules. Note: This plugin has been deprecated in favour of the newer SDK based on componentize-py. To move to the last SDK, uninstall the plugin and visit https://developer.fermyon.com/spin/v2/python-components  ",
   "homepage": "https://github.com/fermyon/spin-python-sdk",
   "version": "0.3.2",
   "spinCompatibility": ">=1.5",

--- a/manifests/py2wasm/py2wasm@0.1.0.json
+++ b/manifests/py2wasm/py2wasm@0.1.0.json
@@ -1,6 +1,6 @@
 {
   "name": "py2wasm",
-  "description": "A plugin to convert Python applications to Spin compatible modules",
+  "description": "A plugin to convert Python applications to Spin compatible modules. Note: This plugin has been deprecated in favour of the newer SDK based on componentize-py. To move to the last SDK, uninstall the plugin and visit https://developer.fermyon.com/spin/v2/python-components  ",
   "homepage": "https://github.com/fermyon/spin-python-sdk",
   "version": "0.1.0",
   "spinCompatibility": ">=0.9",

--- a/manifests/py2wasm/py2wasm@0.1.1.json
+++ b/manifests/py2wasm/py2wasm@0.1.1.json
@@ -1,6 +1,6 @@
 {
   "name": "py2wasm",
-  "description": "A plugin to convert Python applications to Spin compatible modules",
+  "description": "A plugin to convert Python applications to Spin compatible modules. Note: This plugin has been deprecated in favour of the newer SDK based on componentize-py. To move to the last SDK, uninstall the plugin and visit https://developer.fermyon.com/spin/v2/python-components  ",
   "homepage": "https://github.com/fermyon/spin-python-sdk",
   "version": "0.1.1",
   "spinCompatibility": ">=0.9",

--- a/manifests/py2wasm/py2wasm@0.2.0.json
+++ b/manifests/py2wasm/py2wasm@0.2.0.json
@@ -1,6 +1,6 @@
 {
   "name": "py2wasm",
-  "description": "A plugin to convert Python applications to Spin compatible modules",
+  "description": "A plugin to convert Python applications to Spin compatible modules. Note: This plugin has been deprecated in favour of the newer SDK based on componentize-py. To move to the last SDK, uninstall the plugin and visit https://developer.fermyon.com/spin/v2/python-components  ",
   "homepage": "https://github.com/fermyon/spin-python-sdk",
   "version": "0.2.0",
   "spinCompatibility": ">=0.9",

--- a/manifests/py2wasm/py2wasm@0.3.0.json
+++ b/manifests/py2wasm/py2wasm@0.3.0.json
@@ -1,6 +1,6 @@
 {
   "name": "py2wasm",
-  "description": "A plugin to convert Python applications to Spin compatible modules",
+  "description": "A plugin to convert Python applications to Spin compatible modules. Note: This plugin has been deprecated in favour of the newer SDK based on componentize-py. To move to the last SDK, uninstall the plugin and visit https://developer.fermyon.com/spin/v2/python-components  ",
   "homepage": "https://github.com/fermyon/spin-python-sdk",
   "version": "0.3.0",
   "spinCompatibility": ">=1.4",


### PR DESCRIPTION
```bash
Plugin 'py2wasm' was installed successfully!

Description:
        A plugin to convert Python applications to Spin compatible modules. Note: This plugin has been deprecated in favour of the newer SDK based on componentize-py. To move to the last SDK, uninstall the plugin and visit https://developer.fermyon.com/spin/v2/python-components  

```