### PR TITLE
chore(trigger-command): bump to 0.2.0

### DIFF
--- a/manifests/trigger-command/trigger-command.json
+++ b/manifests/trigger-command/trigger-command.json
@@ -1,39 +1,39 @@
 {
   "name": "trigger-command",
   "description": "A Spin trigger that executes the WASI main function of a component.",
-  "version": "0.1",
+  "version": "0.2.0",
   "spinCompatibility": ">=2.0",
   "license": "Apache-2.0",
   "packages": [
     {
-      "os": "macos",
+      "os": "linux",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.2.0/trigger-command-0.2-linux-aarch64.tar.gz",
+      "sha256": "6ed8a6eb3cafeac150b62a03ca46cc7e267352ccc267d4d3ef3f757fe653d9f8"
+    },
+    {
+      "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-macos-amd64.tar.gz",
-      "sha256": "2e222baae3d2c7cbdc4786f8fcd228b8584e151c88b20dedf4ab74a0beebb90b"
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.2.0/trigger-command-0.2-linux-amd64.tar.gz",
+      "sha256": "11bc757d82f273dd0d3848180935bb6cd7cbc824a73d401c33915d8ecd32a79a"
     },
     {
       "os": "windows",
       "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-windows-amd64.tar.gz",
-      "sha256": "5e82070511a8057774b4817770b94d5d19c2f1ee0cf0a63291668456c6c1dcba"
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.2.0/trigger-command-0.2-windows-amd64.tar.gz",
+      "sha256": "4b87700234811d36b18f9301a58c9868eb1d075e96c58588c4067c19bb251b6d"
+    },
+    {
+      "os": "macos",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.2.0/trigger-command-0.2-macos-amd64.tar.gz",
+      "sha256": "9a8fe0aa055cfca33b35ef5461b9a7ee07d4ec1931e3f398a410e5e25b9b118a"
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-macos-aarch64.tar.gz",
-      "sha256": "c6dcad607cc7b9080760420bbec8e2c5c2a25a898fad1564c93be2352d8ae5d4"
-    },
-    {
-      "os": "linux",
-      "arch": "amd64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-linux-amd64.tar.gz",
-      "sha256": "1d12b6d1cf52ae5727c77f4dece29dc92280b9029ef06802db90e88ddeacd407"
-    },
-    {
-      "os": "linux",
-      "arch": "aarch64",
-      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-linux-aarch64.tar.gz",
-      "sha256": "4c4c1ecaaee889f15d409d7e415932ed1bcbb9b4e2750a2ccaef32275adfb2b6"
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.2.0/trigger-command-0.2-macos-aarch64.tar.gz",
+      "sha256": "4fd835ef6e10138a33c44c0f9a849e3a0253e66b5e699730498ac221921c34d4"
     }
   ]
 }

--- a/manifests/trigger-command/trigger-command@0.1.0.json
+++ b/manifests/trigger-command/trigger-command@0.1.0.json
@@ -1,0 +1,39 @@
+{
+  "name": "trigger-command",
+  "description": "A Spin trigger that executes the WASI main function of a component.",
+  "version": "0.1.0",
+  "spinCompatibility": ">=2.0",
+  "license": "Apache-2.0",
+  "packages": [
+    {
+      "os": "macos",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-macos-amd64.tar.gz",
+      "sha256": "2e222baae3d2c7cbdc4786f8fcd228b8584e151c88b20dedf4ab74a0beebb90b"
+    },
+    {
+      "os": "windows",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-windows-amd64.tar.gz",
+      "sha256": "5e82070511a8057774b4817770b94d5d19c2f1ee0cf0a63291668456c6c1dcba"
+    },
+    {
+      "os": "macos",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-macos-aarch64.tar.gz",
+      "sha256": "c6dcad607cc7b9080760420bbec8e2c5c2a25a898fad1564c93be2352d8ae5d4"
+    },
+    {
+      "os": "linux",
+      "arch": "amd64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-linux-amd64.tar.gz",
+      "sha256": "1d12b6d1cf52ae5727c77f4dece29dc92280b9029ef06802db90e88ddeacd407"
+    },
+    {
+      "os": "linux",
+      "arch": "aarch64",
+      "url": "https://github.com/fermyon/spin-trigger-command/releases/download/v0.1.0/trigger-command-0.1-linux-aarch64.tar.gz",
+      "sha256": "4c4c1ecaaee889f15d409d7e415932ed1bcbb9b4e2750a2ccaef32275adfb2b6"
+    }
+  ]
+}


### PR DESCRIPTION
Bump trigger-command to [v0.2.0](https://github.com/fermyon/spin-trigger-command/releases/tag/v0.2.0)