### PR TITLE
feat: add new otel plugin release

### DIFF
--- a/manifests/otel/otel.json
+++ b/manifests/otel/otel.json
@@ -1,39 +1,40 @@
 {
     "name": "otel",
     "description": "A plugin to make working with OTel in Spin easy",
-    "version": "0.1.3",
+    "homepage": "https://github.com/spinframework/otel-plugin",
+    "version": "0.1.4",
     "spinCompatibility": ">=2.5",
     "license": "Apache-2.0",
     "packages": [
-        {
-            "os": "windows",
-            "arch": "amd64",
-            "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.3/otel-0.1.3-windows-amd64.tar.gz",
-            "sha256": "4b56596a35c3e9d11a3ac2d68c4abf92861c457623ac766c1c7718d79fbefb4f"
-        },
-        {
-            "os": "macos",
-            "arch": "amd64",
-            "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.3/otel-0.1.3-macos-amd64.tar.gz",
-            "sha256": "52980e8d4b53cb30c31fe162af559cfd8a918fdbdd8cc1580017698c7ef025cd"
-        },
-        {
-            "os": "linux",
-            "arch": "aarch64",
-            "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.3/otel-0.1.3-linux-aarch64.tar.gz",
-            "sha256": "33dfc7813233148b85f97ab12697bdbf8ab6fad53f29c025c1f020e8099b523c"
-        },
-        {
-            "os": "macos",
-            "arch": "aarch64",
-            "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.3/otel-0.1.3-macos-aarch64.tar.gz",
-            "sha256": "1503a14463273df9daaf845b130d8c4f38a73ba4fbfb737c665a4e8a833af0ac"
-        },
-        {
-            "os": "linux",
-            "arch": "amd64",
-            "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.3/otel-0.1.3-linux-amd64.tar.gz",
-            "sha256": "b025465acfc0c81a84bd61a94bf80e2857708d0195c34e767aea2aaac08a65e1"
-        }
+      {
+        "os": "macos",
+        "arch": "amd64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.4/otel-0.1.4-macos-amd64.tar.gz",
+        "sha256": "e632aecd7e49265498316b568fae2ee5b00852680eb57537ad0eff6c3e93c3da"
+      },
+      {
+        "os": "linux",
+        "arch": "amd64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.4/otel-0.1.4-linux-amd64.tar.gz",
+        "sha256": "9b115bac59c48cca394747270ae551ac343b535c095655a481aaca521104e29c"
+      },
+      {
+        "os": "linux",
+        "arch": "aarch64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.4/otel-0.1.4-linux-aarch64.tar.gz",
+        "sha256": "43004beb138e4009f65b1825fb94d4c082933c39c56f092ba112c29c74f71c14"
+      },
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.4/otel-0.1.4-windows-amd64.tar.gz",
+        "sha256": "d96f9e2f0e7491a16c3c66c2bfe36fffcaaf9773f2b7b53e425351a34a31f4fd"
+      },
+      {
+        "os": "macos",
+        "arch": "aarch64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.4/otel-0.1.4-macos-aarch64.tar.gz",
+        "sha256": "a5c9df8a0af189adf5c098f75db33569f554efe7365bd29f850332e0ea2053cb"
+      }
     ]
 }

--- a/manifests/otel/otel@0.1.0.json
+++ b/manifests/otel/otel@0.1.0.json
@@ -1,7 +1,7 @@
 {
     "name": "otel",
     "description": "A plugin to make working with OTel in Spin easy",
-    "homepage": "https://github.com/fermyon/otel-plugin",
+    "homepage": "https://github.com/spinframework/otel-plugin",
     "version": "0.1.0",
     "spinCompatibility": ">=2.5",
     "license": "Apache-2.0",
@@ -9,31 +9,31 @@
       {
         "os": "windows",
         "arch": "amd64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.0/otel-0.1.0-windows-amd64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.0/otel-0.1.0-windows-amd64.tar.gz",
         "sha256": "1bae55a5d69b2fccd57c844a86e504bd2604a9913868f70496d78d80c5d5891b"
       },
       {
         "os": "macos",
         "arch": "aarch64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.0/otel-0.1.0-macos-aarch64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.0/otel-0.1.0-macos-aarch64.tar.gz",
         "sha256": "abdc70142762024e450042d72b1dd06bef025a05e9f7986dba909e16fd52a020"
       },
       {
         "os": "linux",
         "arch": "aarch64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.0/otel-0.1.0-linux-aarch64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.0/otel-0.1.0-linux-aarch64.tar.gz",
         "sha256": "24725e4bd927c81017fbad15edbdc41c6c3342857c2f750dfc0ddc34bcdcce67"
       },
       {
         "os": "macos",
         "arch": "amd64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.0/otel-0.1.0-macos-amd64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.0/otel-0.1.0-macos-amd64.tar.gz",
         "sha256": "47b3cda08911aa9f5851d622a5baa1d0cba5a0e67c533217d0e97453acb648cd"
       },
       {
         "os": "linux",
         "arch": "amd64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.0/otel-0.1.0-linux-amd64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.0/otel-0.1.0-linux-amd64.tar.gz",
         "sha256": "a09835c92ee4bdf6f3f83f62d444f4a6d25404d0fe10445939c21a7d185219f6"
       }
     ]

--- a/manifests/otel/otel@0.1.1.json
+++ b/manifests/otel/otel@0.1.1.json
@@ -1,7 +1,7 @@
 {
     "name": "otel",
     "description": "A plugin to make working with OTel in Spin easy",
-    "homepage": "https://github.com/fermyon/otel-plugin",
+    "homepage": "https://github.com/spinframework/otel-plugin",
     "version": "0.1.1",
     "spinCompatibility": ">=2.5",
     "license": "Apache-2.0",
@@ -9,31 +9,31 @@
       {
         "os": "windows",
         "arch": "amd64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.1/otel-0.1.1-windows-amd64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.1/otel-0.1.1-windows-amd64.tar.gz",
         "sha256": "4d74268389177603169ba41003b6482f58f5ab0156266437a83f23aec82ef99c"
       },
       {
         "os": "macos",
         "arch": "aarch64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.1/otel-0.1.1-macos-aarch64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.1/otel-0.1.1-macos-aarch64.tar.gz",
         "sha256": "5d347de7266ab723975cd4a0ee5cb73bc32d0c464c342fc32e7c887e0831865d"
       },
       {
         "os": "linux",
         "arch": "aarch64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.1/otel-0.1.1-linux-aarch64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.1/otel-0.1.1-linux-aarch64.tar.gz",
         "sha256": "684ab6476d4c7f9a904cf8fd34d19a2197e931f99c3dbefdab61890157bca328"
       },
       {
         "os": "macos",
         "arch": "amd64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.1/otel-0.1.1-macos-amd64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.1/otel-0.1.1-macos-amd64.tar.gz",
         "sha256": "0fe1b761b22865d3ba9f281a2025383900eb6aa4f7d3b1e26312726388fcfccc"
       },
       {
         "os": "linux",
         "arch": "amd64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.1/otel-0.1.1-linux-amd64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.1/otel-0.1.1-linux-amd64.tar.gz",
         "sha256": "c7f52e22577ea9fa77ba0c922b35d4e0d46833a0469ca8638513694d0097d65b"
       }
     ]

--- a/manifests/otel/otel@0.1.2.json
+++ b/manifests/otel/otel@0.1.2.json
@@ -1,7 +1,7 @@
 {
     "name": "otel",
     "description": "A plugin to make working with OTel in Spin easy",
-    "homepage": "https://github.com/fermyon/otel-plugin",
+    "homepage": "https://github.com/spinframework/otel-plugin",
     "version": "0.1.2",
     "spinCompatibility": ">=2.5",
     "license": "Apache-2.0",
@@ -9,31 +9,31 @@
       {
         "os": "windows",
         "arch": "amd64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.2/otel-0.1.2-windows-amd64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.2/otel-0.1.2-windows-amd64.tar.gz",
         "sha256": "d0bc393d9744610bf27d82c42c16ce1651a227fa90ece2c94e778a6c938f1369"
       },
       {
         "os": "macos",
         "arch": "aarch64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.2/otel-0.1.2-macos-aarch64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.2/otel-0.1.2-macos-aarch64.tar.gz",
         "sha256": "cc0f3fa69e89c34564a5d6822ff0eb588ff6eacb9dd00359db5a93c69ed48f9d"
       },
       {
         "os": "linux",
         "arch": "aarch64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.2/otel-0.1.2-linux-aarch64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.2/otel-0.1.2-linux-aarch64.tar.gz",
         "sha256": "9937bf1ce9ed003226c505cb65ab2e24c80a8e27557b977a11e956d8c568a1ff"
       },
       {
         "os": "macos",
         "arch": "amd64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.2/otel-0.1.2-macos-amd64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.2/otel-0.1.2-macos-amd64.tar.gz",
         "sha256": "fad95f3a14b6d59a2c9d1200add5921b70f1ba68471ad4d9b04b34f714e35bd6"
       },
       {
         "os": "linux",
         "arch": "amd64",
-        "url": "https://github.com/fermyon/otel-plugin/releases/download/v0.1.2/otel-0.1.2-linux-amd64.tar.gz",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.2/otel-0.1.2-linux-amd64.tar.gz",
         "sha256": "996460b69e919e047084124b87900c80bffb83912332360cc1a1e3234a2e017e"
       }
     ]

--- a/manifests/otel/otel@0.1.3.json
+++ b/manifests/otel/otel@0.1.3.json
@@ -1,0 +1,40 @@
+{
+    "name": "otel",
+    "description": "A plugin to make working with OTel in Spin easy",
+    "homepage": "https://github.com/spinframework/otel-plugin",
+    "version": "0.1.3",
+    "spinCompatibility": ">=2.5",
+    "license": "Apache-2.0",
+    "packages": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.3/otel-0.1.3-windows-amd64.tar.gz",
+        "sha256": "4b56596a35c3e9d11a3ac2d68c4abf92861c457623ac766c1c7718d79fbefb4f"
+      },
+      {
+        "os": "macos",
+        "arch": "amd64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.3/otel-0.1.3-macos-amd64.tar.gz",
+        "sha256": "52980e8d4b53cb30c31fe162af559cfd8a918fdbdd8cc1580017698c7ef025cd"
+      },
+      {
+        "os": "linux",
+        "arch": "aarch64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.3/otel-0.1.3-linux-aarch64.tar.gz",
+        "sha256": "33dfc7813233148b85f97ab12697bdbf8ab6fad53f29c025c1f020e8099b523c"
+      },
+      {
+        "os": "macos",
+        "arch": "aarch64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.3/otel-0.1.3-macos-aarch64.tar.gz",
+        "sha256": "1503a14463273df9daaf845b130d8c4f38a73ba4fbfb737c665a4e8a833af0ac"
+      },
+      {
+        "os": "linux",
+        "arch": "amd64",
+        "url": "https://github.com/spinframework/otel-plugin/releases/download/v0.1.3/otel-0.1.3-linux-amd64.tar.gz",
+        "sha256": "b025465acfc0c81a84bd61a94bf80e2857708d0195c34e767aea2aaac08a65e1"
+      }
+    ]
+}


### PR DESCRIPTION
We recently moved the otel plugin to the spinframework org. This PR updates to the newest release of the plugin as well as updating the artifact URLs to the correct org.