### PR TITLE
chore(MAINTAINERS.md): update vdice as emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,8 +8,9 @@
 | **karthik2804** | Karthik Ganeshram |
 | **kate-goldenring** | Kate Goldenring |
 | **bacongobbler** | Matthew Fisher |
-| **vdice** | Vaughn Dice |
 
 ## Emeritus Maintainers
 
-None
+| GitHub Username | Name |
+| --- | --- |
+| **vdice** | Vaughn Dice |


### PR DESCRIPTION
I will be taking an open-ended sabbatical from software development for a good 6 months at minimum, so per [Spin's governance guidelines](https://github.com/spinframework/governance/blob/main/GOVERNANCE.md#project-maintainers), I'm updating my maintainer status to emeritus.

Ref https://github.com/spinframework/spin/pull/3581